### PR TITLE
Migrate to Dagger Hilt part 2 (Activity)

### DIFF
--- a/app/src/main/java/jp/co/clockvoid/chaser/view/home/MainActivity.kt
+++ b/app/src/main/java/jp/co/clockvoid/chaser/view/home/MainActivity.kt
@@ -23,7 +23,6 @@ class MainActivity : AppCompatActivity(), HasAndroidInjector {
     override fun androidInjector(): AndroidInjector<Any> = dispatchingAndroidInjector
 
     override fun onCreate(savedInstanceState: Bundle?) {
-
         super.onCreate(savedInstanceState)
 
         AndroidInjection.inject(this)


### PR DESCRIPTION
# Description
Dagger Android SupportからHIltへマイグレートするための下準備をします．

# Implementation
- MainActivityに`@AndroindEntryPoint`annotationを追加
  - そのために，`HasAndroidInjector`を継承するように変更．

前回の #5 とこれを適用することにより，Fragmentをmigrateできるようになった．最終的には`HasAndroidInjector`とか`@ContributeAndroidInjector`とかが全部消える算段

# Screenshots
- 画面の変更はなし

# Links
- [ドキュメント](https://dagger.dev/hilt/migration-guide#2-migrate-activities-and-fragments-and-other-classes)
