### PR TITLE
Alcoholのsentiment level実装

### DIFF
--- a/feature/alcohol/src/main/java/jp/co/clockvoid/chaser/feature/alcohol/ui/AnalyticsItem.kt
+++ b/feature/alcohol/src/main/java/jp/co/clockvoid/chaser/feature/alcohol/ui/AnalyticsItem.kt
@@ -62,7 +62,11 @@ fun AnalyticsItem(title: String, body: String, sentimentLevel: Int, isLast: Bool
                     .layoutId("bodyTextView"),
             )
             Image(
-                vectorResource(id = R.drawable.ic_sentiment_satisfied_black_24dp),
+                vectorResource(id = when (sentimentLevel) {
+                    0 -> R.drawable.ic_sentiment_very_satisfied_black_24dp
+                    1 -> R.drawable.ic_sentiment_satisfied_black_24dp
+                    else -> R.drawable.ic_sentiment_very_dissatisfied_black_24dp
+                }),
                 modifier = Modifier
                     .aspectRatio(1f)
                     .layoutId("sentimentImageView")


### PR DESCRIPTION
# Description
Alcoholタブのsentiment leveを実装

# Implementation
- AnalyticsItem.ktでsentiment levelに応じたdrawableの出し分け機構を記述

# Screenshots
- 動画になるので省略

# Links
https://www.notion.so/Alcohol-SentimentLevel-8a96e881616d4375b13c4f233280d03c