### PR TITLE
fix: to avoid bug around lint in AGP 4.2.0-alpha13

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,6 +48,12 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
+
+    // solution to https://issuetracker.google.com/issues/170026127
+    // There is a bug around lint tool that is bundled with AGP 4.2.0-alpha13
+    lintOptions {
+        disable("InvalidFragmentVersionForActivityResult")
+    }
 }
 
 kapt {


### PR DESCRIPTION
# Description
https://issuetracker.google.com/issues/170026127
のバグを回避するために一時的に`InvalidFragmentVersionForActivityResult`のlintを無効化します

# Implementation
- `InvalidFragmentVersionForActivityResult`のLintを無効化

# Screenshots
- 画面の変更なし

# Links
- https://issuetracker.google.com/issues/170026127