### PR TITLE
Update to Android Studio 4.1 Canary 14

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -32,8 +32,10 @@ jobs:
         chmod +x ./gradlew
         ./gradlew build
 
-    - name: Upload apk file
-      uses: actions/upload-artifact@v1
-      with:
-        name: apk
-        path: app/build/outputs/apk/debug/app-debug.apk
+  # Upload to Artifacts
+  # Deleted because of lack of discspace on GitHub Actions
+  # - name: Upload apk file
+  #   uses: actions/upload-artifact@v1
+  #   with:
+  #     name: apk
+  #     path: app/build/outputs/apk/debug/app-debug.apk

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,12 +48,6 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
-
-    // solution to https://issuetracker.google.com/issues/170026127
-    // There is a bug around lint tool that is bundled with AGP 4.2.0-alpha13
-    lintOptions {
-        disable("InvalidFragmentVersionForActivityResult")
-    }
 }
 
 kapt {

--- a/buildSrc/src/main/java/dependencies/Dependencies.kt
+++ b/buildSrc/src/main/java/dependencies/Dependencies.kt
@@ -3,7 +3,7 @@ package dependencies
 @Suppress("unused")
 object Dependencies {
     object GradlePlugin {
-        const val android = "com.android.tools.build:gradle:4.2.0-alpha13"
+        const val android = "com.android.tools.build:gradle:4.2.0-alpha14"
     }
 
     object Kotlin {

--- a/buildSrc/src/main/java/dependencies/Versions.kt
+++ b/buildSrc/src/main/java/dependencies/Versions.kt
@@ -1,11 +1,12 @@
 package dependencies
 
-@Suppress("unused,WeakerAccess")
+@Suppress("unused")
 object Versions {
+    @SuppressWarnings("WeakerAccess")
     const val compileSdkVersion: Int = 29
     const val minSdkVersion: Int = 23
     const val targetSdkVersion: Int = compileSdkVersion
-    const val buildToolsVersion: String = "30.0.0"
+    const val buildToolsVersion: String = "30.0.2"
 
     private const val versionMajor: Int = 1
     private const val versionMinor: Int = 0

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m
+org.gradle.jvmargs=-Xmx8g
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-4-all.zip


### PR DESCRIPTION
# Description
Android Studio 4.2 Canary 14がリリースされたのでアップデートしました
- https://androidstudio.googleblog.com/2020/10/android-studio-42-canary-14-available.html

# Implementation
- Dependencies.ktの`GradlePlugin.android`の値をCanary 14のものに変更
- gradle-wrapper.propertiesの`distributionUrl`をGradle 6.7 rc 4のものに変更（Canary 14からこのバージョンが最低ヴァージョンになった）
- `:app`モジュールのbuild.gradle.ktsのActivityのLintのバグ対応のためのモンキーパッチを削除（Canary 14で修正された）
- Versions.ktの`build`buildToolsVersion`buildToolsVersion`を3.0.2に変更（Canary 14から3.0.0を指定しても自動的に3.0.2を使うようになった）
- GitHub ActionsのArtifacts用のストレージが足りなくなったようなので、アップロードを無効化した

# Screenshots
- 画面の変更はありません

# Links
- https://androidstudio.googleblog.com/2020/10/android-studio-42-canary-14-available.html
