### PR TITLE
Update Android Gradle Plugin to 4.2 alpha 15

### DIFF
--- a/buildSrc/src/main/java/dependencies/Dependencies.kt
+++ b/buildSrc/src/main/java/dependencies/Dependencies.kt
@@ -3,7 +3,7 @@ package dependencies
 @Suppress("unused")
 object Dependencies {
     object GradlePlugin {
-        const val android = "com.android.tools.build:gradle:4.2.0-alpha14"
+        const val android = "com.android.tools.build:gradle:4.2.0-alpha15"
     }
 
     object Kotlin {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip


### PR DESCRIPTION
# Description
Android Studio 4.2 Canary 15がリリースされたのでアップデートしました

# Implementation
- Dependencies.ktの当該行を15に変更
- Gradle Wrapperの設定を変更し、使用するGradleのバージョンを6.7にした

# Screenshots
- 画面の変更はなし

# Links
