### PR TITLE
Delete dependencies for gms-oss-license-plugin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,7 +11,6 @@ plugins {
 
     // https://github.com/jmatsu/license-list-plugin
     id("io.github.jmatsu.license-list") version ("0.6.1")
-    id("com.google.android.gms.oss-licenses-plugin")
 }
 
 android {
@@ -86,8 +85,6 @@ dependencies {
 
     // leak canary
     debugImplementation(Dependencies.leakCanary)
-
-    implementation(Dependencies.GmsOssLicense.runtime)
 
     testImplementation("junit:junit:4.12")
     androidTestImplementation("androidx.test.ext:junit:1.1.1")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,9 +23,5 @@
         <activity
             android:name=".components.license.LicenseHtmlActivity"
             android:label="@string/open_source_license" />
-
-        <activity
-            android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
-            android:theme="@style/Theme.Chaser.OssLicense" />
     </application>
 </manifest>

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ buildscript {
         classpath(Dependencies.Kotlin.gradlePlugin)
         classpath(Dependencies.AndroidX.Navigation.gradlePlugin)
         classpath(Dependencies.Dagger.Hilt.plugin)
-        classpath(Dependencies.GmsOssLicense.gradlePlugin)
     }
 }
 

--- a/buildSrc/src/main/java/dependencies/Dependencies.kt
+++ b/buildSrc/src/main/java/dependencies/Dependencies.kt
@@ -93,11 +93,6 @@ object Dependencies {
         }
     }
 
-    object GmsOssLicense {
-        const val gradlePlugin = "com.google.android.gms:oss-licenses-plugin:0.10.2"
-        const val runtime = "com.google.android.gms:play-services-oss-licenses:17.0.0"
-    }
-
     object Hyperion {
         private const val version = "0.9.27"
         const val core = "com.willowtreeapps.hyperion:hyperion-core:$version"


### PR DESCRIPTION
# Description
GmsOssLicenseのGradle Pluginが他のモジュールの依存関係にアクセスできない関係で大量の警告をはいていたので削除。
そのうちマルチモジュール対応するだろうということでずっと待ってたけど一向に対応しないのでもう使うのやめる。

# Implementation
- Android ManifestからGmsOssLicenseが提供するActivityを削除
- Dependencies.ktから依存関係の定義を削除
- app/build.gradle.ktsから`implementation`を削除

# Screenshots

# Links
