### PR TITLE
Fix saving last shown screen

### DIFF
--- a/components/license/src/main/res/layout/activity_component_license_html.xml
+++ b/components/license/src/main/res/layout/activity_component_license_html.xml
@@ -14,7 +14,7 @@
             android:id="@+id/toolbar"
             style="@style/MainToolBarStyle"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="?attr/actionBarSize"
             tools:title="OSS Licenses" />
     </com.google.android.material.appbar.AppBarLayout>
 

--- a/components/setting/src/main/res/layout/activity_setting.xml
+++ b/components/setting/src/main/res/layout/activity_setting.xml
@@ -16,7 +16,7 @@
             android:id="@+id/toolBar"
             style="@style/MainToolBarStyle"
             android:layout_width="match_parent"
-            android:layout_height="?android:attr/actionBarSize"
+            android:layout_height="?attr/actionBarSize"
             app:title="@string/setting_title" />
     </com.google.android.material.appbar.AppBarLayout>
 

--- a/components/setting/src/main/res/xml/chaser_preferences.xml
+++ b/components/setting/src/main/res/xml/chaser_preferences.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+<PreferenceScreen
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <CheckBoxPreference

--- a/data/repository-impl/src/main/java/jp/co/clockvoid/chaser/data/repositoryimpl/PreferenceStorageImpl.kt
+++ b/data/repository-impl/src/main/java/jp/co/clockvoid/chaser/data/repositoryimpl/PreferenceStorageImpl.kt
@@ -18,7 +18,7 @@ class PreferenceStorageImpl @Inject constructor(
     override var isAlcoholVisible by BooleanPreference(prefs, PREF_IS_ALCOHOL_VISIBLE, true)
     override var isCaffeineVisible by BooleanPreference(prefs, PREF_IS_CAFFEINE_VISIBLE, true)
     override var isCigaretteVisible by BooleanPreference(prefs, PREF_IS_CIGARETTE_VISIBLE, true)
-    override var lastShownFragment: Int by IntPreference(prefs, PREF_LAST_SHOWN_FRAGMENT, -1)
+    override var lastShownFragment: String? by StringPreference(prefs, PREF_LAST_SHOWN_FRAGMENT)
 
     companion object {
         private const val PREFS_NAME = "jp.co.clockvoid.chaser_preferences"
@@ -64,7 +64,7 @@ private class BooleanPreference(
 private class StringPreference(
     private val prefs: SharedPreferences,
     private val name: String,
-    private val defaultValue: String?
+    private val defaultValue: String? = null
 ) : ReadWriteProperty<Any, String?> {
 
     @WorkerThread

--- a/data/repository/src/main/java/jp/co/clockvoid/chaser/data/repository/PreferenceStorage.kt
+++ b/data/repository/src/main/java/jp/co/clockvoid/chaser/data/repository/PreferenceStorage.kt
@@ -4,5 +4,5 @@ interface PreferenceStorage {
     var isAlcoholVisible: Boolean
     var isCaffeineVisible: Boolean
     var isCigaretteVisible: Boolean
-    var lastShownFragment: Int
+    var lastShownFragment: String?
 }


### PR DESCRIPTION
# Description
最後に表示した画面の保存機構に`R.id`で振られる番号を使用していたため，アプリを再インストールするとクラッシュするようになる問題があったので修正

# Implementation
- SharedPreferencesの`lastShownScreenFragment`という変数を`Int`から`String?`に変更
- 最後に表示した画面のタイトルを`lastShownScreenFragment`に保存するようにした

# Screenshots
- 画面の変更はなし

# Links
