### PR TITLE
Fix theme of preference screen

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Build with Gradle
       run: |
         chmod +x ./gradlew
-        ./gradlew build
+        ./gradlew :app:lintDebug
 
   # Upload to Artifacts
   # Deleted because of lack of discspace on GitHub Actions

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,6 @@
             </intent-filter>
         </activity>
 
-        <activity android:name=".components.setting.SettingActivity" />
 
         <activity
             android:name=".components.license.LicenseHtmlActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,6 @@
             </intent-filter>
         </activity>
 
-
         <activity
             android:name=".components.license.LicenseHtmlActivity"
             android:label="@string/open_source_license" />

--- a/components/setting/src/main/AndroidManifest.xml
+++ b/components/setting/src/main/AndroidManifest.xml
@@ -3,5 +3,10 @@
     package="jp.co.clockvoid.chaser.components.setting">
 
     <application
-        android:theme="@style/Theme.Chaser.DayNight" />
+        android:theme="@style/Theme.Chaser.DayNight">
+
+        <activity
+            android:name=".SettingActivity"
+            android:theme="@style/Theme.Chaser.Preference" />
+    </application>
 </manifest>

--- a/components/setting/src/main/java/jp/co/clockvoid/chaser/components/setting/SettingActivity.kt
+++ b/components/setting/src/main/java/jp/co/clockvoid/chaser/components/setting/SettingActivity.kt
@@ -4,9 +4,9 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import androidx.preference.CheckBoxPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.SwitchPreference
 import jp.co.clockvoid.chaser.components.license.License
 import jp.co.clockvoid.chaser.components.setting.databinding.ActivitySettingBinding
 
@@ -62,7 +62,7 @@ class SettingActivity : AppCompatActivity() {
     class SettingsFragment : PreferenceFragmentCompat() {
         override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
             setPreferencesFromResource(R.xml.chaser_preferences, rootKey)
-            val visibleList: List<CheckBoxPreference?> = listOf(
+            val visibleList: List<SwitchPreference?> = listOf(
                 findPreference("is_alcohol_visible"),
                 findPreference("is_caffeine_visible"),
                 findPreference("is_cigarette_visible")

--- a/components/setting/src/main/res/xml/chaser_preferences.xml
+++ b/components/setting/src/main/res/xml/chaser_preferences.xml
@@ -2,19 +2,19 @@
 <PreferenceScreen
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <CheckBoxPreference
+    <SwitchPreference
         app:key="is_alcohol_visible"
         app:title="@string/display_alcohol"
         app:defaultValue="true"
         app:icon="@drawable/ic_local_bar_black_24dp" />
 
-    <CheckBoxPreference
+    <SwitchPreference
         app:key="is_caffeine_visible"
         app:title="@string/display_caffeine"
         app:defaultValue="true"
         app:icon="@drawable/ic_local_cafe_black_24dp" />
 
-    <CheckBoxPreference
+    <SwitchPreference
         app:key="is_cigarette_visible"
         app:title="@string/display_cigarette"
         app:defaultValue="true"

--- a/core/android/src/main/res/values/themes.xml
+++ b/core/android/src/main/res/values/themes.xml
@@ -43,7 +43,12 @@
         <item name="md_color_widget">?attr/colorPrimary</item>
     </style>
 
-    <style name="Theme.Chaser.DayNight" parent="Theme.Chaser" />
+    <style name="Theme.Chaser.DayNight" parent="Theme.Chaser">
+    </style>
+
+    <style name="Theme.Chaser.Preference" pareng="Theme.Chaser">
+        <item name="colorSecondary">?attr/colorPrimary</item>
+    </style>
 
     <style name="Theme.Chaser.OssLicense" parent="Theme.AppCompat.Light">
         <!-- color -->


### PR DESCRIPTION
# Description
設定画面の色がおかしかったので直しました．
具体的には，PreferenceScreenを使っている関係上，アクセント色にMaterial Themeの`colorSecondary`が使用されてしまい，少し違和感があったため，これを`colorPrimary`を使うように変更しました．

# Implementation
- `Theme.Chaser.Preference`を作成し，`colorSecondary`に`?attr/colorPrimary`を指定．
- AndroidManifestでSettingActivityのThemeに`Theme.Chaser.Preference`を指定
- 今までCheckBoxPreferenceを使用していたが，SwitchPreferenceに変更

# Screenshots
before | after
--- | ---
<img src="https://user-images.githubusercontent.com/6965122/105036504-ea2c3e00-5a9f-11eb-9925-d95ca558fc85.jpg" width="250" /> | <img src="https://user-images.githubusercontent.com/6965122/105036512-ed272e80-5a9f-11eb-9d59-f795710d1356.jpg" width="250" />


# Links
