### PR TITLE
Fix dark theme for SettingActivity

### DIFF
--- a/components/setting/src/main/java/jp/co/clockvoid/chaser/components/setting/SettingActivity.kt
+++ b/components/setting/src/main/java/jp/co/clockvoid/chaser/components/setting/SettingActivity.kt
@@ -3,12 +3,15 @@ package jp.co.clockvoid.chaser.components.setting
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import android.util.TypedValue
+import androidx.annotation.ColorInt
 import androidx.appcompat.app.AppCompatActivity
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
 import jp.co.clockvoid.chaser.components.license.License
 import jp.co.clockvoid.chaser.components.setting.databinding.ActivitySettingBinding
+
 
 /**
  * SettingActivity
@@ -66,10 +69,14 @@ class SettingActivity : AppCompatActivity() {
                 findPreference("is_alcohol_visible"),
                 findPreference("is_caffeine_visible"),
                 findPreference("is_cigarette_visible")
-
             )
             visibleList.map { item ->
                 requireNotNull(item)
+                val typedValue = TypedValue()
+                val theme = requireContext().theme
+                theme.resolveAttribute(R.attr.colorOnBackground, typedValue, true)
+                @ColorInt val color = typedValue.data
+                item.icon.setTint(color)
                 item.setOnPreferenceChangeListener { _, newValue ->
                     visibleList.forEach { it!!.isEnabled = true }
                     val checked = visibleList.filter { it!!.isChecked && (newValue == false && it == item).not() }

--- a/core/android/src/main/res/values-night/themes.xml
+++ b/core/android/src/main/res/values-night/themes.xml
@@ -25,4 +25,8 @@
     </style>
 
     <style name="Theme.Chaser.DayNight" parent="Theme.Chaser.Dark" />
+
+    <style name="Theme.Chaser.Preference" parent="Theme.Chaser.Dark">
+        <item name="colorSecondary">?attr/colorPrimary</item>
+    </style>
 </resources>

--- a/core/android/src/main/res/values/themes.xml
+++ b/core/android/src/main/res/values/themes.xml
@@ -44,21 +44,9 @@
         <item name="md_color_widget">?attr/colorPrimary</item>
     </style>
 
-    <style name="Theme.Chaser.DayNight" parent="Theme.Chaser">
-    </style>
+    <style name="Theme.Chaser.DayNight" parent="Theme.Chaser" />
 
     <style name="Theme.Chaser.Preference" pareng="Theme.Chaser">
         <item name="colorSecondary">?attr/colorPrimary</item>
-    </style>
-
-    <style name="Theme.Chaser.OssLicense" parent="Theme.AppCompat.Light">
-        <!-- color -->
-        <item name="android:textColorPrimary">@color/black</item>
-        <item name="colorPrimary">@color/white</item>
-        <item name="colorOnPrimary">@color/black</item>
-        <item name="colorOnBackground">@color/black</item>
-        <item name="android:colorBackground">@color/white</item>
-        <item name="android:statusBarColor">@color/white</item>
-        <item name="android:windowLightStatusBar">true</item>
     </style>
 </resources>


### PR DESCRIPTION
# Description
SettingActivityのダークテーマ対応がぶっ壊れていたので修正

# Implementation
- values-nightにTheme.Chaser.Preferenceを作成
- SettingActivityのアイコンに`colorOnBackground`を適用させるためにContextからThemeをとってきて`R.attr.colorOnBackground`の`@ColorInt`を引っ張ってくるコードを書いた

# Screenshots
before | after
--- | ---
<img src="https://user-images.githubusercontent.com/6965122/105187064-b15e9880-5b75-11eb-97d1-0d567ba395cb.png" width="250" /> | <img src="https://user-images.githubusercontent.com/6965122/105187066-b3285c00-5b75-11eb-9d93-5799184a4e53.png" width="250" />

# Links
