### PR TITLE
Add link to license page on license list activity

### DIFF
--- a/components/license/src/main/java/jp/co/clockvoid/chaser/components/license/LicenseListAdapter.kt
+++ b/components/license/src/main/java/jp/co/clockvoid/chaser/components/license/LicenseListAdapter.kt
@@ -1,5 +1,9 @@
 package jp.co.clockvoid.chaser.components.license
 
+import android.os.Build
+import android.text.Html
+import android.text.Spanned
+import android.text.method.LinkMovementMethod
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.view.isGone
@@ -60,10 +64,21 @@ class LicenseListAdapter
             copyrightTextView.isGone = item.developers.isEmpty()
             urlTextView.text = item.url
             urlTextView.isGone = item.url.isNullOrEmpty()
-            licenseTextView.text = item.licenses.foldIndexed("") { index, acc, item ->
-                "$acc${if (index != 0) ", " else ""}${item.license}"
-            }
+            licenseTextView.text = fromHtml(item.licenses.foldIndexed("Under ") { index, acc, item ->
+                "$acc${if (index != 0) ", " else ""}<a href=\"${item.license_url}\">${item.license}</a>"
+            })
+            licenseTextView.movementMethod = LinkMovementMethod.getInstance()
             licenseTextView.isGone = item.licenses.isEmpty()
+        }
+    }
+
+    private fun fromHtml(html: String): Spanned {
+
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            Html.fromHtml(html, Html.FROM_HTML_MODE_LEGACY)
+        } else {
+            @Suppress("DEPRECATION")
+            Html.fromHtml(html)
         }
     }
 }

--- a/components/license/src/main/res/layout/item_license_list.xml
+++ b/components/license/src/main/res/layout/item_license_list.xml
@@ -47,7 +47,7 @@
             android:id="@+id/licenseTextView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textAppearance="?attr/textAppearanceOverline"
+            android:textAppearance="?attr/textAppearanceBody2"
             app:layout_constraintTop_toBottomOf="@id/urlTextView"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
# Description
ライセンスページのライセンス文へのリンクがなかったので貼りました．

# Implementation
- `item_license_list`のライセンスを表示するところをハイパーリンク化

# Screenshots
before | after
--- | ---
<img src="https://user-images.githubusercontent.com/6965122/105572047-08dc4e80-5d98-11eb-9f17-acf6ed85d0cd.png" width="250" /> | <img src="https://user-images.githubusercontent.com/6965122/105572018-e5190880-5d97-11eb-9e4a-59d223b60f4f.png" width="250" />

# Links
