### PR TITLE
Fix toLoweCase() to lowercase()

### DIFF
--- a/components/license/src/main/java/jp/co/clockvoid/chaser/components/license/LicenseActivityViewModel.kt
+++ b/components/license/src/main/java/jp/co/clockvoid/chaser/components/license/LicenseActivityViewModel.kt
@@ -34,6 +34,7 @@ data class OssLicense(
     val license_url: String
 )
 
+@ExperimentalStdlibApi // TODO: This is for String#lowercase(). Delete when kotlin version is 1.5.0
 @HiltViewModel
 class LicenseActivityViewModel @Inject constructor(
     @ApplicationContext val context: Context
@@ -51,9 +52,9 @@ class LicenseActivityViewModel @Inject constructor(
         viewModelScope.launch {
             filterQuery.collect { query ->
                 _packageLicenseList.value = holeLicenseList?.filter { license ->
-                    val regex = Regex(query.toLowerCase())
-                    val project = license.project.toLowerCase() ?: ""
-                    val description = license.description?.toLowerCase() ?: ""
+                    val regex = Regex(query.lowercase())
+                    val project = license.project.lowercase()
+                    val description = license.description?.lowercase() ?: ""
                     regex.containsMatchIn(project) or regex.containsMatchIn(description)
                 } ?: emptyList()
             }


### PR DESCRIPTION
# Description
- `toLowerCase()`とか言う関数を使用しているところでLocaleが指定されていないというWarningが出ていたので修正
-  `toLowerCase()`は文字列を小文字にする関数だが，これはUnicodeのCase Mappingという規格に沿って実装されており，使用言語によって結果が変わってしまう
- 今回は比較対象すべてを自前で小文字化するので，全部一定の条件で小文字化すれば問題はないはず
- Kotlin 1.5.0でstableになる`lowercase()`関数は中で`toLoweCase(Locale.ROOT)`しており，ロケールに関係なく一定の条件で小文字化できるため，こちらを採用することにした

# Implementation
- `toLowerCase()`を使用しているところを`lowercase()`に変えた
- `lowecase()`は現状使用しているKotlin 1.4.32ではexperimentalのため，アノテーションを追加
  - 1.5.0に上げたら消す

# Screenshots
- 画面の変更はなし

# Links
